### PR TITLE
Add quotes around email address

### DIFF
--- a/multimail.py
+++ b/multimail.py
@@ -15,7 +15,7 @@ DEFAULT_RECIPIENTS_FILE = 'recipients.csv'
 DEFAULT_MESSAGE_FILE = 'message.txt'
 
 # Commands
-CMD = 'mutt -s "%(subject)s" %(extras)s -- %(recipient)s < "%(message-file)s"'
+CMD = 'mutt -s "%(subject)s" %(extras)s -- "%(recipient)s" < "%(message-file)s"'
 CC = '-c "%(cc)s" '
 BCC = '-b "%(bcc)s" '
 ATTACH = '-a %(attachment)s '


### PR DESCRIPTION
Pulling in improvements by @baldwint — thanks for improving, and hope you don't mind! :smiley:

This enables recipient addresses to be specified in non-bare form. For example: `Alice Wonderland <alice@example.com>` instead of `alice@example.com`.
