### PR TITLE
Addition of alternate muttrc file usage & from name and address specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ It follows the following format:
     cc: email@example.com
     bcc: email@example.com
     attachment: picture.jpg
+    fromadd: test@example.com
+    fromname: Testing_123
 
 A field need not be filled out, but its label must appear.
 (e.g., you can have the attachment field be empty,
@@ -67,6 +69,8 @@ __the attachment field supports the same placeholders as the message__.
 So if you want user-specific attachments, just use a placeholder in the
 configuration file and put the filename (or portion of it) in the respective
 column of the recipients file.
+
+The 'fromname:' option can't (at the moment) have spaces in; so "Testing_123" works, "Testing 123" doesn't.
 
 
 ### How to send ###

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ It follows the following format:
     cc: email@example.com
     bcc: email@example.com
     attachment: picture.jpg
+    muttrc: temp_muttrc
     fromadd: test@example.com
     fromname: Testing_123
 
@@ -69,6 +70,8 @@ __the attachment field supports the same placeholders as the message__.
 So if you want user-specific attachments, just use a placeholder in the
 configuration file and put the filename (or portion of it) in the respective
 column of the recipients file.
+
+An alternative .muttrc file can be specified (equivalent of calling mutt with -F temp_muttrc).
 
 The 'fromname:' option can't (at the moment) have spaces in; so "Testing_123" works, "Testing 123" doesn't.
 

--- a/example/batch.cfg
+++ b/example/batch.cfg
@@ -3,3 +3,5 @@ subject: Terrible News
 cc:
 bcc:
 attachment: picture.jpg
+fromadd: 
+fromname: 

--- a/example/batch.cfg
+++ b/example/batch.cfg
@@ -3,5 +3,6 @@ subject: Terrible News
 cc:
 bcc:
 attachment: picture.jpg
+muttrc: temp_muttrc
 fromadd: 
 fromname: 

--- a/multimail.py
+++ b/multimail.py
@@ -124,10 +124,12 @@ def multimail(config_filename, personalization_filename, message_filename):
 
         # The same pattern matching is applied to the attachment.
         if attachment != '':
-            attachment = personalize_message(attachment, recipient)
+            attachment_name = personalize_message(attachment, recipient)
+        else:
+            attachment_name = ''
 
         # Send the message!
-        send_message(personalized_message, subject, address, cc, bcc, attachment, fromadd, fromname)
+        send_message(personalized_message, subject, address, cc, bcc, attachment_name, fromadd, fromname)
         
 def main():
     config_file = DEFAULT_CONFIG_FILE


### PR DESCRIPTION
Updates allow the user to define what muttrc file to use for the merge.

Additional options added are to allow one-off setting of 'from name' and 'from address'. This means a custom .muttrc does not need to be created for a quick send, and all the relevant settings remain in the batch.cfg. 
